### PR TITLE
Add PQ KEM support to CMS encryption scripts

### DIFF
--- a/encrypt_file.sh
+++ b/encrypt_file.sh
@@ -4,16 +4,33 @@ set -euo pipefail
 usage() {
   cat <<EOF
 Usage: $(basename "$0") -r /path/to/recipient_cert.pem -i INPUT -o OUTPUT
-Encrypt INPUT into CMS (DER) using AES-256-GCM and RSA recipient.
+Encrypt INPUT into CMS (DER) using AES-256-GCM content encryption and a
+post-quantum (KEM) recipient.
 Options:
-  -r  Recipient certificate (PEM, contains RSA public key)
+  -r  Recipient certificate (PEM, contains ML-KEM/X.509 public key)
   -i  Input file (to encrypt)
   -o  Output CMS file (e.g., file.cms)
+Environment:
+  CMS_KEM_ALG           KEM algorithm (default: ML-KEM-768)
+  CMS_WRAP_CIPHER       Key wrapping cipher (default: AES-256-KWP)
+  CMS_CONTENT_CIPHER    Content cipher flag (default: aes-256-gcm)
+  OPENSSL_BIN           openssl executable to invoke (default: openssl)
 Notes:
-  * Uses: openssl cms -encrypt -aes-256-gcm -inform/outform DER
+  * Uses: openssl cms -encrypt (KEMRecipientInfo)
   * Does NOT log secrets. Filenames only.
 EOF
 }
+
+CMS_KEM_ALG="${CMS_KEM_ALG:-ML-KEM-768}"
+CMS_WRAP_CIPHER="${CMS_WRAP_CIPHER:-AES-256-KWP}"
+CMS_CONTENT_CIPHER_FLAG="${CMS_CONTENT_CIPHER:-aes-256-gcm}"
+CMS_CONTENT_CIPHER_FLAG="${CMS_CONTENT_CIPHER_FLAG,,}"
+
+OPENSSL_BIN="${OPENSSL_BIN:-openssl}"
+
+[ -n "${CMS_KEM_ALG}" ] || { echo "ERR: CMS_KEM_ALG must not be empty" >&2; exit 2; }
+[ -n "${CMS_WRAP_CIPHER}" ] || { echo "ERR: CMS_WRAP_CIPHER must not be empty" >&2; exit 2; }
+[ -n "${CMS_CONTENT_CIPHER_FLAG}" ] || { echo "ERR: CMS_CONTENT_CIPHER must not be empty" >&2; exit 2; }
 
 RECIP=""
 IN=""
@@ -34,17 +51,30 @@ done
 [ -n "${OUT}" ] || { echo "ERR: output path missing"; exit 2; }
 
 tmp="${OUT}.part"
-echo "[encrypt] ⏳ Encrypting '${IN}' → '${OUT}' (CMS, AES-256-GCM)…"
+echo "[encrypt] ⏳ Encrypting '${IN}' → '${OUT}' (CMS, ${CMS_CONTENT_CIPHER_FLAG} / ${CMS_KEM_ALG})…"
+
+cleanup_tmp() {
+  rm -f -- "${tmp}" 2>/dev/null || true
+}
+
+trap cleanup_tmp EXIT
 
 # -binary preserves exact bytes; -stream handles large files with low memory.
-openssl cms -encrypt \
-  -binary -stream \
-  -aes-256-gcm \
-  -in  "${IN}" \
-  -out "${tmp}" \
-  -outform DER \
-  "${RECIP}"
+if ! "${OPENSSL_BIN}" cms -encrypt \
+    -binary -stream \
+    "-${CMS_CONTENT_CIPHER_FLAG}" \
+    -in  "${IN}" \
+    -out "${tmp}" \
+    -outform DER \
+    -keyopt "kem_cipher:${CMS_KEM_ALG}" \
+    -keyopt "wrap_cipher:${CMS_WRAP_CIPHER}" \
+    "${RECIP}"; then
+  status=$?
+  echo "ERR: openssl cms -encrypt failed (ensure ${CMS_KEM_ALG} KEM support is available)." >&2
+  exit "$status"
+fi
 
 # Atomic move
 mv -f -- "${tmp}" "${OUT}"
+trap - EXIT
 echo "[encrypt] ✅ Wrote CMS envelope: ${OUT}"


### PR DESCRIPTION
## Summary
- switch the CMS envelope generation to require a post-quantum KEM recipient with ML-KEM defaults
- make the encryption tooling configurable via environment variables and hardened temporary file handling
- update the decrypt watcher to call OpenSSL with the new KEM- and wrap-cipher options

## Testing
- bash -n encrypt_file.sh decrypt_watch.sh

------
https://chatgpt.com/codex/tasks/task_e_68d6e945bbd4832ab04f91581e0569e6